### PR TITLE
:bug: Add missing link to home page

### DIFF
--- a/src/components/widgets/Tools.astro
+++ b/src/components/widgets/Tools.astro
@@ -33,6 +33,12 @@ const items = [
 		icon: 'carbon:xml',
 		slug: 'json-xml-converter',
 	},
+	{
+		title: 'Hashing',
+		description: 'Hash your payload using many different algorithms',
+		icon: 'carbon:xml',
+		slug: 'json-xml-converter',
+	},
 ];
 ---
 


### PR DESCRIPTION
Adding the hashing tool to the homepage list was missed in the previous PR  https://github.com/CloudHelvetica/tooli/pull/6