### PR TITLE
:bug: Missing icon for hash tool

### DIFF
--- a/src/components/widgets/Tools.astro
+++ b/src/components/widgets/Tools.astro
@@ -36,8 +36,8 @@ const items = [
 	{
 		title: 'Hashing',
 		description: 'Hash your payload using many different algorithms',
-		icon: 'carbon:xml',
-		slug: 'json-xml-converter',
+		icon: 'mdi:function-variant',
+		slug: 'hash',
 	},
 ];
 ---


### PR DESCRIPTION
Missing icon for the `hash` tool because i got sloppy and rushed a copy-paste