### PR TITLE
:bug: Fix broken links

### DIFF
--- a/src/components/widgets/Error404.astro
+++ b/src/components/widgets/Error404.astro
@@ -1,5 +1,4 @@
 ---
-import { getHomePermalink } from '~/utils/permalinks';
 ---
 
 <section class="flex items-center h-full p-16">
@@ -13,12 +12,7 @@ import { getHomePermalink } from '~/utils/permalinks';
 			<p class="mt-4 mb-8 text-lg text-gray-600 dark:text-slate-400">
 				But dont worry, you can find plenty of other things on our homepage.
 			</p>
-			<a
-				rel="noopener noreferrer"
-				href={getHomePermalink()}
-				class="btn ml-4"
-				>Back to homepage</a
-			>
+			<a rel="noopener noreferrer" href="/" class="btn ml-4">Back to homepage</a>
 		</div>
 	</div>
 </section>

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -71,7 +71,7 @@ import ToggleTheme from '~/components/core/ToggleTheme.astro';
 				<div class="hidden items-center md:flex">
 					<ToggleTheme iconClass="w-5 h-5" />
 					<a
-						href="roadmap"
+						href="/roadmap"
 						class="inline-block text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5"
 						aria-label="Development Roadmap"
 					>


### PR DESCRIPTION
The link to the roadmap and home page were relative to the page the user was on, and therefore were broken at any depth > 1